### PR TITLE
Two uses for alternative host frame

### DIFF
--- a/draft-joras-sconepro-quic-protocol-alt.md
+++ b/draft-joras-sconepro-quic-protocol-alt.md
@@ -200,7 +200,7 @@ send a new request of QUIC version but to the network devices
 IP address and port instead of using the same 4-tuple than the
 corresponsing end-to-end QUIC connection. Alternatively, it can also
 be used to setup a full QUIC version 1 connection from the client to the nextwork
-device to obtain confidentiality and authentication of the communication. 
+device to obtain confidentiality and authentication of the communication.
 
 ~~~
 Alternative Hosts Frame {

--- a/draft-joras-sconepro-quic-protocol-alt.md
+++ b/draft-joras-sconepro-quic-protocol-alt.md
@@ -198,7 +198,7 @@ Payload:
 Used to communicate alternative endpoints. This can be used to
 send a new request of QUIC version but to the network devices
 IP address and port instead of using the same 4-tuple than the
-corresponsing end-to-end QUIC connection. Alternative it can also
+corresponsing end-to-end QUIC connection. Alternatively, it can also
 be used to setup a full QUIC version 1 connection from the client to the nextwork
 device to obtain confidentiality and authentication of the communication. 
 

--- a/draft-joras-sconepro-quic-protocol-alt.md
+++ b/draft-joras-sconepro-quic-protocol-alt.md
@@ -195,8 +195,12 @@ Payload:
 
 ## Alternative Hosts Frame
 
-Used to communicate alternative endpoints to which a client can connect to
-obtain confidentiality of the communication.
+Used to communicate alternative endpoints. This can be used to
+send a new request of QUIC version but to the network devices
+IP address and port instead of using the same 4-tuple than the
+corresponsing end-to-end QUIC connection. Alternative it can also
+be used to setup a full QUIC version 1 connection from the client to the nextwork
+device to obtain confidentiality and authentication of the communication. 
 
 ~~~
 Alternative Hosts Frame {


### PR DESCRIPTION
Proposal to use this Frame for two things: for setting up a quic v1  connection or simply a new version quic connection to the IP of the network device.